### PR TITLE
project: added support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - 3.4
   - 3.5
+  - 3.6
 
 addons:
   apt:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35
+envlist = py34, py35, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Since pylint is not a blocker anymore, uhu is now tested against
Python 3.6 version too.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>