### PR TITLE
core: resolves links in archives generated by dump_package_archive

### DIFF
--- a/uhu/core/utils.py
+++ b/uhu/core/utils.py
@@ -38,7 +38,8 @@ def dump_package_archive(package, output=None, force=False):
     metadata and all objects files.
 
     All objects are renamed to its hash and moved to the archive
-    root. Objects are included without duplication.
+    root. Objects are included without duplication and links are
+    resolved.
     """
     # Checks minimum package requirements
     if package.version is None:
@@ -70,5 +71,5 @@ def dump_package_archive(package, output=None, force=False):
                 if sha256sum in cache:
                     continue
                 cache.add(sha256sum)
-                tar.add(obj.filename, sha256sum)
+                tar.add(os.path.realpath(obj.filename), sha256sum)
     return output


### PR DESCRIPTION
dump_package_archive now resovles all kind of links (hard and
symbolic) when adding members into archive.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>