### PR TITLE
updatehub: fixes bug when uploading package objects

### DIFF
--- a/uhu/updatehub/api.py
+++ b/uhu/updatehub/api.py
@@ -33,7 +33,6 @@ class ObjectReader:  # pylint: disable=too-few-public-methods
 
 
 def dummy_object_upload(filename, url, callback=None):
-    url = url.replace('updatehub-artifacts', 'nothing')
     data = ObjectReader(filename, callback)
     try:
         http.put(url, data=data, sign=False)


### PR DESCRIPTION
A debug code line was still within code and it is now removed.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>