### PR TITLE
repl: fixed prompt_object_options return value type

### DIFF
--- a/tests/core/test_validators.py
+++ b/tests/core/test_validators.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2017 O.S. Systems Software LTDA.
+# SPDX-License-Identifier: GPL-2.0
+
+import unittest
+
+from uhu.core.validators import validate_option_requirements
+
+
+class ValidateOptionRequirementsTestCase(unittest.TestCase):
+
+    def test_values_argument_type_checking(self):
+        with self.assertRaises(TypeError):
+            validate_option_requirements(None, {'key': 'value'})

--- a/uhu/core/validators.py
+++ b/uhu/core/validators.py
@@ -3,7 +3,7 @@
 
 from copy import deepcopy
 
-from ._options import Options
+from ._options import OptionType, Options
 from .install_condition import normalize_install_if_different
 
 
@@ -97,8 +97,15 @@ def validate_options_requirements(values):
 
 def validate_option_requirements(option, values):
     """Verifies if option requirements are satisfied."""
+    # validate values argument
+    for key in values.keys():
+        if not isinstance(key, OptionType):
+            err = 'values argument must have OptionType keys type (got {}).'
+            raise TypeError(err.format(type(key)))
+
     if not option.requirements:
         return
+
     for req_option, req_value in option.requirements.items():
         if req_option not in values:
             err = ('You must specify a value for "{}" '

--- a/uhu/repl/helpers.py
+++ b/uhu/repl/helpers.py
@@ -119,12 +119,12 @@ def prompt_object_options(n_sets, object_mode):
     :param n_sets: The number of installation sets in package.
     :param object_mode: A string indicating the object mode.
     """
-    options = {}
+    values = {}
     mode = Modes.get(object_mode)
     mode_options = [opt for opt in mode.options if not opt.volatile]
     for option in mode_options:
         try:
-            validate_option_requirements(option, options)
+            validate_option_requirements(option, values)
         except ValueError:
             continue  # requirements not satisfied, skip this option
         if option.symmetric:
@@ -141,8 +141,9 @@ def prompt_object_options(n_sets, object_mode):
                         default=default,
                     ))
             value = tuple(value)
-        options[option.metadata] = value
-    return options
+        values[option] = value
+    values = {opt.metadata: value for opt, value in values.items()}
+    return values
 
 
 def prompt_object_mode():


### PR DESCRIPTION
Previously, repl.helpers.prompt_object_options was returning a dict
with string keys. This was making validation of object option
requirements fail inadvertently. Consequently, prompt of sub
options (eg. format options, install condition configuration, etc)
never happened because they depend on this validation.

A type checking was added into uhu.core.validate_option_requirements
to prevent this kind of bug. This modification made
repl.helpers.prompt_object_options tests fail as expected. Finally, a
proper fix was applied into prompt_object_options.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>