### PR TITLE
config: improved updatehub credentials getter

### DIFF
--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -66,13 +66,10 @@ class ConfigCommandTestCase(
         result = self.runner.invoke(get_command, args=['no-existent'])
         self.assertEqual(result.output, '')
 
-    def test_can_set_init_commandial_configuration(self):
+    def test_can_set_init_command_configuration(self):
         self.runner.invoke(init_command, input='1234\nasdf')
-        config = ConfigParser()
-        config.read(self.config_filename)
-        id_ = config.get(AUTH_SECTION, 'access_id')
-        secret = config.get(AUTH_SECTION, 'access_secret')
-        self.assertEqual(id_, '1234')
+        access, secret = self.config.get_credentials()
+        self.assertEqual(access, '1234')
         self.assertEqual(secret, 'asdf')
 
 

--- a/tests/repl/test_config.py
+++ b/tests/repl/test_config.py
@@ -11,7 +11,7 @@ from uhu.repl import functions
 class PackageTestCase(unittest.TestCase):
 
     @patch('uhu.repl.functions.prompt')
-    @patch('uhu.repl.functions.config.set_initial')
+    @patch('uhu.repl.functions.config.set_credentials')
     def test_can_set_authentication_credentials(self, set_initial, prompt):
         prompt.side_effect = ['access', 'secret']
         functions.set_authentication()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,17 +66,13 @@ class ConfigTestCase(FileFixtureMixin, EnvironmentFixtureMixin, UHUTestCase):
         self.config.set(key, value, section=section)
         self.assertEqual(self.config.get(key, section=section), value)
 
-    def test_set_initial_configuration(self):
-        expected_id = 'id'
+    def test_can_set_and_get_crendetials(self):
+        expected_access = 'id'
         expected_secret = 'secret'
-
-        self.config.set_initial(expected_id, expected_secret)
-
-        observed_id = self.config.get('access_id', section=AUTH_SECTION)
-        observed_secret = self.config.get('access_secret', AUTH_SECTION)
-
-        self.assertEqual(observed_id, expected_id)
-        self.assertEqual(observed_secret, expected_secret)
+        self.config.set_credentials(expected_access, expected_secret)
+        access, secret = self.config.get_credentials()
+        self.assertEqual(access, expected_access)
+        self.assertEqual(secret, expected_secret)
 
     def test_set_command_does_not_override_previous_settings(self):
         self.config.set('foo', 'bar')
@@ -95,3 +91,7 @@ class ConfigTestCase(FileFixtureMixin, EnvironmentFixtureMixin, UHUTestCase):
         self.config.set('foo', 'foo bar')
         self.assertEqual(self.config.get('foo'), 'foo bar')
         self.assertEqual(self.config.get('control'), 'control')
+
+    def test_get_credentials_raises_error_if_no_credentials_are_set(self):
+        with self.assertRaises(ValueError):
+            self.config.get_credentials()

--- a/uhu/cli/config.py
+++ b/uhu/cli/config.py
@@ -16,9 +16,9 @@ def config_cli():
 @config_cli.command(name='init')
 def init_command():
     """Sets uhu required initial configuration."""
-    access_id = input('UpdateHub Access Key ID: ')
-    access_secret = input('UpdateHub Systems Secret Access Key: ')
-    config.set_initial(access_id, access_secret)
+    access = input('UpdateHub Access Key ID: ')
+    secret = input('UpdateHub Systems Secret Access Key: ')
+    config.set_credentials(access, secret)
 
 
 @config_cli.command(name='set')

--- a/uhu/config.py
+++ b/uhu/config.py
@@ -4,7 +4,7 @@
 import configparser
 import os
 
-from .utils import get_global_config_file
+from .utils import get_global_config_file, get_credentials
 
 
 MAIN_SECTION = 'settings'
@@ -24,15 +24,29 @@ class Config:
         self._config = configparser.ConfigParser(
             default_section=MAIN_SECTION)
 
+    def get_credentials(self):
+        env_credentials = get_credentials()
+        config_credentials = self.get_credentials_from_config()
+        credentials = env_credentials or config_credentials
+        if not credentials:
+            raise ValueError('Could not find any crendentials.')
+        return credentials
+
+    def set_credentials(self, access_id, access_secret):
+        """Set server requried credentials."""
+        self.set('access_id', access_id, section=AUTH_SECTION)
+        self.set('access_secret', access_secret, section=AUTH_SECTION)
+
+    def get_credentials_from_config(self):
+        access = self.get('access_id', AUTH_SECTION)
+        secret = self.get('access_secret', AUTH_SECTION)
+        if access and secret:
+            return access, secret
+
     def _read(self):
         if os.path.exists(self._filename):
             self._config.read(self._filename)
         open(self._filename, 'a').close()
-
-    def set_initial(self, access_id, access_secret):
-        """Set server requried credentials."""
-        self.set('access_id', access_id, section=AUTH_SECTION)
-        self.set('access_secret', access_secret, section=AUTH_SECTION)
 
     def set(self, key, value, section=None):
         """Adds a new entry on settings based on key and value."""

--- a/uhu/repl/functions.py
+++ b/uhu/repl/functions.py
@@ -18,7 +18,7 @@ def set_authentication():
     """Sets user access and secret keys."""
     access = prompt('UpdateHub Access Key ID: ')
     secret = prompt('UpdateHub Systems Secret Access Key: ')
-    config.set_initial(access, secret)
+    config.set_credentials(access, secret)
 
 
 # Product

--- a/uhu/repl/repl.py
+++ b/uhu/repl/repl.py
@@ -11,7 +11,7 @@ from prompt_toolkit.contrib.regular_languages.completion import GrammarCompleter
 from prompt_toolkit.contrib.regular_languages import compiler
 
 from .. import get_version
-from ..config import config, AUTH_SECTION
+from ..config import config
 from ..core.package import Package
 from ..core.utils import dump_package, load_package
 from ..utils import get_local_config_file
@@ -187,8 +187,8 @@ def repl(package):
     Before creating a new instance, checks if server authentication is
     set. If not, prompts user for its credentials.
     """
-    access = config.get('access_id', AUTH_SECTION)
-    secret = config.get('access_secret', AUTH_SECTION)
-    if not all([access, secret]):
+    try:
+        config.get_credentials()
+    except ValueError:
         functions.set_authentication()
     return UHURepl(package).repl()

--- a/uhu/updatehub/http.py
+++ b/uhu/updatehub/http.py
@@ -3,14 +3,10 @@
 
 import requests
 
-from ._request import Request
+from ._request import Request, HTTPError
 
 
 UNKNOWN_ERROR = 'A unexpected request error ocurred. Try again later.'
-
-
-class HTTPError(requests.RequestException):
-    """A generic error for HTTP requests."""
 
 
 def request(method, url, *args, sign=True, **kwargs):
@@ -20,6 +16,8 @@ def request(method, url, *args, sign=True, **kwargs):
         else:
             response = requests.request(
                 method, url, *args, timeout=30, **kwargs)
+    except HTTPError as error:
+        raise error
     except (requests.exceptions.MissingSchema,
             requests.exceptions.InvalidSchema,
             requests.exceptions.URLRequired,

--- a/uhu/utils.py
+++ b/uhu/utils.py
@@ -4,17 +4,20 @@
 import os
 
 
-# Environment variables (only for testing)
+# Environment variables
 CHUNK_SIZE_VAR = 'UHU_CHUNK_SIZE'
 GLOBAL_CONFIG_VAR = 'UHU_GLOBAL_CONFIG'
 LOCAL_CONFIG_VAR = 'UHU_LOCAL_CONFIG'
 SERVER_URL_VAR = 'UHU_SERVER_URL'
+ACCESS_ID_VAR = 'UHU_ACCESS_ID'
+ACCESS_SECRET_VAR = 'UHU_ACCESS_SECRET'
+
 
 # Default values
 DEFAULT_CHUNK_SIZE = 1024 * 128  # 128 KiB
 DEFAULT_GLOBAL_CONFIG_FILE = os.path.expanduser('~/.uhu')
 DEFAULT_LOCAL_CONFIG_FILE = '.uhu'
-DEFAULT_SERVER_URL = 'http://0.0.0.0'  # TO DO: replace by the right URL
+DEFAULT_SERVER_URL = 'http://0.0.0.0'  # TODO: replace by the right URL
 
 
 def get_chunk_size():
@@ -34,6 +37,13 @@ def get_global_config_file():
 
 def get_local_config_file():
     return os.environ.get(LOCAL_CONFIG_VAR, DEFAULT_LOCAL_CONFIG_FILE)
+
+
+def get_credentials():
+    access = os.environ.get(ACCESS_ID_VAR)
+    secret = os.environ.get(ACCESS_SECRET_VAR)
+    if access and secret:
+        return access, secret
 
 
 def remove_local_config():


### PR DESCRIPTION
uhu config main object has now 2 main methods, get_credentials and
set_credentials, both used to get and set UpdateHub server access key
and access secret.

Config.get_credentials is able to get user credentials from
environment (with UHU_ACCESS_ID and UHU_ACCESS_SECRET variables) and
from ~/.uhu file. Environment variables are priorized. Also,
get_credentials raises an error if no credential is provided. This
helps clients to deal properly if users have not set its credentials.

With this modifications all config module dependents (updatehub, repl
and cli) were update to follow what is stated above.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>