### PR TITLE
Adds package signing feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'humanize>=0.5.1',
         'progress>=1.1',
         'prompt-toolkit>=0.57',
+        'pycrypto',
         'updatehub-package-schema>=1.0.0a3',
         'requests>=2',
         'rfc3987>=1.3',

--- a/tests/core/test_install_condition.py
+++ b/tests/core/test_install_condition.py
@@ -8,7 +8,7 @@ import unittest
 
 from uhu.core import install_condition as ic
 from uhu.core.install_condition import (
-    normalize_install_if_different, KNOWN_PATTERNS)
+    normalize_install_if_different, KNOWN_PATTERNS, InstallCondition)
 from uhu.core.object import Object
 
 from utils import FileFixtureMixin, UHUTestCase
@@ -588,3 +588,27 @@ class InstallIfDifferentNormalizationTestCase(unittest.TestCase):
                 'version': '2.0',
                 'pattern': {},
             }))
+
+
+class InstallConditionToMetadataTestCase(unittest.TestCase):
+
+    def test_raises_error_if_invalid_condition(self):
+        invalid_conditions = [None, 1, 'unknown', 'grub']
+        for condition in invalid_conditions:
+            with self.assertRaises(ValueError):
+                obj = {
+                    'filename': __file__,
+                    'install-condition': condition,
+                }
+                InstallCondition(obj).to_metadata()
+
+    def test_raises_error_if_invalid_pattern(self):
+        invalid_patterns = [None, 1, 'unknown', 'grub']
+        for pattern in invalid_patterns:
+            with self.assertRaises(ValueError):
+                obj = {
+                    'filename': __file__,
+                    'install-condition': InstallCondition.VERSION_DIVERGES,
+                    'install-condition-pattern-type': pattern,
+                }
+                InstallCondition(obj).to_metadata()

--- a/uhu/core/compression.py
+++ b/uhu/core/compression.py
@@ -86,3 +86,14 @@ def get_uncompressed_size(fn, compressor_name):
     cmd = compressor['cmd'] % fn
     size = subprocess.check_output(cmd, shell=True)
     return int(size.decode())
+
+
+def compression_to_metadata(filename):
+    compressor = get_compressor_format(filename)
+    size = get_uncompressed_size(filename, compressor)
+    if size is None:
+        return {}
+    return {
+        'compressed': True,
+        'required-uncompressed-size': size,
+    }

--- a/uhu/core/utils.py
+++ b/uhu/core/utils.py
@@ -8,6 +8,8 @@ from collections import OrderedDict
 
 import pkgschema
 
+from ..utils import sign_dict
+
 
 def dump_package(package, fn):
     """Dumps a package into a file."""
@@ -62,6 +64,7 @@ def dump_package_archive(package, output=None, force=False):
     # Writes archive
     cache = set()
     with zipfile.ZipFile(output, mode='w') as archive:
+        archive.writestr('signature', sign_dict(metadata))
         archive.writestr('metadata', json.dumps(metadata))
         for obj in package.objects.all():
             sha256sum = obj['sha256sum']

--- a/uhu/updatehub/_request.py
+++ b/uhu/updatehub/_request.py
@@ -19,7 +19,9 @@ class HTTPError(requests.RequestException):
 
 class Request:
 
-    def __init__(self, url, method, payload='', json=False, **requests_kwargs):
+    # pylint: disable=too-many-arguments
+    def __init__(self, url, method, payload='', json=False,
+                 headers=None, **requests_kwargs):
         self.url = url
         self._url = urlparse(self.url)
         self.method = method.upper()
@@ -29,6 +31,7 @@ class Request:
         self.date = datetime.now(timezone.utc)
         self.payload_sha256 = self._generate_payload_sha256()
 
+        headers = headers if headers else {}
         self.headers = {
             'User-Agent': 'updatehub-utils/{}'.format(get_version()),
             'Host': self._url.netloc,
@@ -37,6 +40,7 @@ class Request:
             'Api-Content-Type': 'application/vnd.updatehub-v1+json',
             'Accept': 'application/json',
         }
+        self.headers.update(headers)
         if json:
             self.headers['Content-Type'] = 'application/json'
 

--- a/uhu/updatehub/api.py
+++ b/uhu/updatehub/api.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 from pkgschema import validate_metadata, ValidationError
 
-from uhu.utils import call, get_server_url, get_chunk_size
+from uhu.utils import call, get_server_url, get_chunk_size, sign_dict
 from . import http
 
 
@@ -81,9 +81,12 @@ def upload_metadata(metadata):
     except ValidationError:
         raise UpdateHubError('You have an invalid package metadata.')
     url = get_server_url('/packages')
+    signature = sign_dict(metadata)
     payload = json.dumps(metadata)
+    headers = {'UH-SIGNATURE': signature}
     try:
-        response = http.post(url, payload=payload, json=True).json()
+        response = http.post(
+            url, payload=payload, json=True, headers=headers).json()
         return response['uid']
     except http.HTTPError as error:
         raise UpdateHubError('Could not upload metadata: {}'.format(error))


### PR DESCRIPTION
These modifications make uhu able to sign packages, both by pushing or by making a uhupkg.

A RSA private key is necessary to sign the package. It can be passed to uhu using UHU_PRIVATE_KEY environment variable.