### PR TITLE
Add support for version detection on other more compression formats for arm zImage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install Dependencies
         run: |
-          sudo apt-get update; sudo apt-get install lzop xz-utils gzip
+          sudo apt-get update; sudo apt-get install lzop xz-utils gzip libarchive-dev
           pip install tox coveralls
       - name: Run Tox
         run: tox -e py

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ python_requires = >=3.4
 install_requires =
     click >= 6.5
     humanize >= 0.5.1
+    libarchive-c >= 2.9
     progress >= 1.1
     prompt-toolkit >=2.0.0, <3.0.0
     pycryptodomex

--- a/uhu/core/install_condition.py
+++ b/uhu/core/install_condition.py
@@ -31,9 +31,8 @@ def check(phrase, regexp):
         return results[0].decode()
 
 
-def find(fp, pattern, iterable, seek=0):
+def find(pattern, iterable):
     """Generic function to find some text in some iterable."""
-    fp.seek(seek)
     regexp = re.compile(pattern)
     phrase = b''
     for chunk in iterable:
@@ -94,11 +93,11 @@ def get_arm_z_image_version(fp):
     # "0x1f 0x8b 0x08" is the beginning of the gzipped kernel file
     start = bytearray.fromhex('1f 8b 08 00 00 00 00 00')
     # This could be improved so we don't have to read all file in memory
-    seek = fp.read().index(start)
+    fp.seek(fp.read().index(start))
     pattern = br'Linux version (\S+).*'
     decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
     iterable = iter(lambda: decompressor.decompress(fp.read(30)), b'')
-    return find(fp, pattern, iterable, seek)
+    return find(pattern, iterable)
 
 
 def get_arm_u_image_version(fp):
@@ -155,9 +154,10 @@ def get_kernel_version(fp):
 
 def get_uboot_version(fp):
     """Returns U-Boot object version."""
+    fp.seek(0)
     pattern = br'U-Boot(?: SPL)? (\S+) \(.*\)'
     iterable = iter(lambda: fp.read(30), b'')
-    result = find(fp, pattern, iterable, 0)
+    result = find(pattern, iterable)
     if result is not None:
         return result
     raise ValueError('Cannot retrive U-Boot version')
@@ -167,8 +167,9 @@ def get_uboot_version(fp):
 
 def get_object_version(fp, pattern, seek=0, buffer_size=-1):
     """Returns version of any type of object."""
+    fp.seek(seek)
     iterable = iter(lambda: fp.read(buffer_size), b'')
-    result = find(fp, pattern, iterable, seek)
+    result = find(pattern, iterable)
     if result is not None:
         return result
     raise ValueError('Cannot retrive object version')

--- a/uhu/core/install_condition.py
+++ b/uhu/core/install_condition.py
@@ -96,7 +96,7 @@ def get_arm_z_image_version(fp):
     fp.seek(fp.read().index(start))
     pattern = br'Linux version (\S+).*'
     decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
-    iterable = iter(lambda: decompressor.decompress(fp.read(30)), b'')
+    iterable = iter(lambda: decompressor.decompress(fp.read(512)), b'')
     return find(pattern, iterable)
 
 


### PR DESCRIPTION
This also includes some other changes:
- Removed seek from inner find function;
  - Functions that send the iterator are reponsable for making sure the iterator works as intended; 
- Raise decompression chunk size;
  - On some compressed images, the smaller chunk size was resulting in empty reads from zlib;
- Move from zlib to libarchive;
  - This help us have a generic api for handling all the supported compression formats for kernel images.